### PR TITLE
Create coord transformation on demand

### DIFF
--- a/src/main/java/org/matsim/stuttgart/Utils.java
+++ b/src/main/java/org/matsim/stuttgart/Utils.java
@@ -1,8 +1,7 @@
 package org.matsim.stuttgart;
+
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.core.config.groups.PlanCalcScoreConfigGroup;
 import org.matsim.core.utils.geometry.CoordinateTransformation;
@@ -20,10 +19,6 @@ import java.util.List;
 
 public class Utils {
 
-    private static final Logger logger = LogManager.getLogger("UtilsLogger");
-    private static final CoordinateTransformation transformation = TransformationFactory.getCoordinateTransformation("EPSG:4326", "EPSG:25832");
-
-
     // Copied from https://github.com/matsim-vsp/mosaik-2/blob/master/src/main/java/org/matsim/mosaik2/Utils.java
     public static List<PlanCalcScoreConfigGroup.ActivityParams> createTypicalDurations(String type, long minDurationInSeconds, long maxDurationInSeconds, long durationDifferenceInSeconds) {
 
@@ -37,7 +32,7 @@ public class Utils {
     }
 
     public static CoordinateTransformation getTransformationWGS84ToUTM32() {
-        return transformation;
+        return TransformationFactory.getCoordinateTransformation("EPSG:4326", "EPSG:25832");
     }
 
     public static VehicleType createVehicleType(String id, double length, double maxV, double pce, VehiclesFactory factory) {
@@ -66,5 +61,4 @@ public class Utils {
             return sharedSvn;
         }
     }
-
 }


### PR DESCRIPTION
Create coord transformation on demand. Otherwise this calls the geotools coord transformation api, when anything in utils is used. This sometimes crashes matsim runs, which use differen utils methods

Signed-off-by: Janekdererste <laudan@tu-berlin.de>